### PR TITLE
Import ruby onigmo patches

### DIFF
--- a/onigmo.h
+++ b/onigmo.h
@@ -357,8 +357,11 @@ int onigenc_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar** pp, c
 
 ONIG_EXTERN
 int onigenc_mbclen_approximate(const OnigUChar* p,const OnigUChar* e, const struct OnigEncodingTypeST* enc);
+ONIG_EXTERN
+int onigenc_mbclen(const OnigUChar* p,const OnigUChar* e, const struct OnigEncodingTypeST* enc);
 
-#define ONIGENC_MBC_ENC_LEN(enc,p,e)           onigenc_mbclen_approximate(p,e,enc)
+#define ONIGENC_MBC_ENC_LEN_APPROX(enc,p,e)   onigenc_mbclen_approximate(p,e,enc)
+#define ONIGENC_MBC_ENC_LEN(enc,p,e)          onigenc_mbclen(p,e,enc)
 #define ONIGENC_MBC_MAXLEN(enc)               ((enc)->max_enc_len)
 #define ONIGENC_MBC_MAXLEN_DIST(enc)           ONIGENC_MBC_MAXLEN(enc)
 #define ONIGENC_MBC_MINLEN(enc)               ((enc)->min_enc_len)

--- a/regcomp.c
+++ b/regcomp.c
@@ -3747,10 +3747,8 @@ setup_comb_exp_check(Node* node, int state, ScanEnv* env)
   switch (type) {
   case NT_LIST:
     {
-      Node* prev = NULL_NODE;
       do {
 	r = setup_comb_exp_check(NCAR(node), r, env);
-	prev = NCAR(node);
       } while (r >= 0 && IS_NOT_NULL(node = NCDR(node)));
     }
     break;

--- a/regenc.c
+++ b/regenc.c
@@ -52,6 +52,21 @@ onigenc_set_default_encoding(OnigEncoding enc)
 }
 
 extern int
+onigenc_mbclen(const OnigUChar* p,const OnigUChar* e, OnigEncoding enc)
+{
+  int ret = ONIGENC_PRECISE_MBC_ENC_LEN(enc, p, e);
+  if (ONIGENC_MBCLEN_CHARFOUND_P(ret)) {
+    ret = ONIGENC_MBCLEN_CHARFOUND_LEN(ret);
+    if (ret > (int)(e - p)) ret = (int)(e - p); // just for case
+    return ret;
+  }
+  else if (ONIGENC_MBCLEN_NEEDMORE_P(ret)) {
+    return (int)(e - p);
+  }
+  return p < e ? 1 : 0;
+}
+
+extern int
 onigenc_mbclen_approximate(const OnigUChar* p,const OnigUChar* e, OnigEncoding enc)
 {
   int ret = ONIGENC_PRECISE_MBC_ENC_LEN(enc, p, e);

--- a/regenc.h
+++ b/regenc.h
@@ -91,6 +91,7 @@ typedef struct {
 #define ONIG_CHECK_NULL_RETURN_VAL(p,val)  if (ONIG_IS_NULL(p)) return (val)
 
 #define enclen(enc,p,e) ((enc->max_enc_len == enc->min_enc_len) ? enc->min_enc_len : ONIGENC_MBC_ENC_LEN(enc,p,e))
+#define enclen_approximate(enc,p,e) ((enc->max_enc_len == enc->min_enc_len) ? enc->min_enc_len : ONIGENC_MBC_ENC_LEN_APPROX(enc,p,e))
 
 /* character types bit flag */
 #define BIT_CTYPE_NEWLINE  (1<< ONIGENC_CTYPE_NEWLINE)

--- a/regexec.c
+++ b/regexec.c
@@ -3092,7 +3092,8 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
 	else {
 	  STACK_PUSH_ALT(p + addr, s, sprev, pkeep); /* Push possible point. */
-	  n = enclen(encode, s, end);
+	  /* For approximating enclen. Strict version of enclen does not work here. */
+	  n = enclen_approximate(encode, s, end);
 	  STACK_PUSH_ABSENT_POS(absent, ABSENT_END_POS); /* Save the original pos. */
 	  STACK_PUSH_ALT(selfp, s + n, s, pkeep); /* Next iteration. */
 	  STACK_PUSH_ABSENT;

--- a/regexec.c
+++ b/regexec.c
@@ -3159,6 +3159,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #endif
 
       MOP_OUT;
+      CHECK_INTERRUPT_IN_MATCH_AT;
       JUMP;
 
     DEFAULT

--- a/regexec.c
+++ b/regexec.c
@@ -1178,11 +1178,13 @@ static int string_cmp_ic(OnigEncoding enc, int case_fold_flag,
 # define DATA_ENSURE_CHECK1    (s < right_range)
 # define DATA_ENSURE_CHECK(n)  (s + (n) <= right_range)
 # define DATA_ENSURE(n)        if (s + (n) > right_range) goto fail
+# define DATA_ENSURE_CONTINUE(n) if (s + (n) > right_range) continue
 # define ABSENT_END_POS        right_range
 #else
 # define DATA_ENSURE_CHECK1    (s < end)
 # define DATA_ENSURE_CHECK(n)  (s + (n) <= end)
 # define DATA_ENSURE(n)        if (s + (n) > end) goto fail
+# define DATA_ENSURE_CONTINUE(n) if (s + (n) > end) continue
 # define ABSENT_END_POS        end
 #endif /* USE_MATCH_RANGE_MUST_BE_INSIDE_OF_SPECIFIED_RANGE */
 
@@ -2635,7 +2637,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 		  ? STACK_AT(mem_end_stk[mem])->u.mem.pstr
 		  : (UChar* )((void* )mem_end_stk[mem]));
 	  n = pend - pstart;
-	  DATA_ENSURE(n);
+	  DATA_ENSURE_CONTINUE(n);
 	  sprev = s;
 	  swork = s;
 	  STRING_CMP_VALUE(pstart, swork, n, is_fail);
@@ -2674,7 +2676,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 		  ? STACK_AT(mem_end_stk[mem])->u.mem.pstr
 		  : (UChar* )((void* )mem_end_stk[mem]));
 	  n = pend - pstart;
-	  DATA_ENSURE(n);
+	  DATA_ENSURE_CONTINUE(n);
 	  sprev = s;
 	  swork = s;
 	  STRING_CMP_VALUE_IC(case_fold_flag, pstart, &swork, n, end, is_fail);

--- a/regexec.c
+++ b/regexec.c
@@ -421,6 +421,7 @@ onig_region_copy(OnigRegion* to, const OnigRegion* from)
   (msa).start    = (arg_start);\
   (msa).gpos     = (arg_gpos);\
   (msa).best_len = ONIG_MISMATCH;\
+  (msa).counter  = 0;\
 } while(0)
 #else
 # define MATCH_ARG_INIT(msa, arg_option, arg_region, arg_start, arg_gpos) do {\
@@ -429,6 +430,7 @@ onig_region_copy(OnigRegion* to, const OnigRegion* from)
   (msa).region   = (arg_region);\
   (msa).start    = (arg_start);\
   (msa).gpos     = (arg_gpos);\
+  (msa).counter  = 0;\
 } while(0)
 #endif
 

--- a/regexec.c
+++ b/regexec.c
@@ -601,7 +601,7 @@ stack_double(OnigStackType** arg_stk_base, OnigStackType** arg_stk_end,
   (((s) - str) * num_comb_exp_check + ((snum) - 1))
 # define STATE_CHECK_VAL(v,snum) do {\
   if (state_check_buff != NULL) {\
-    int x = STATE_CHECK_POS(s,snum);\
+    ptrdiff_t x = STATE_CHECK_POS(s,snum);\
     (v) = state_check_buff[x/8] & (1<<(x%8));\
   }\
   else (v) = 0;\
@@ -610,7 +610,7 @@ stack_double(OnigStackType** arg_stk_base, OnigStackType** arg_stk_end,
 
 # define ELSE_IF_STATE_CHECK_MARK(stk) \
   else if ((stk)->type == STK_STATE_CHECK_MARK) { \
-    int x = STATE_CHECK_POS(stk->u.state.pstr, stk->u.state.state_check);\
+    ptrdiff_t x = STATE_CHECK_POS(stk->u.state.pstr, stk->u.state.state_check);\
     state_check_buff[x/8] |= (1<<(x%8));				\
   }
 
@@ -3525,7 +3525,7 @@ onig_match(regex_t* reg, const UChar* str, const UChar* end, const UChar* at, On
   MATCH_ARG_INIT(msa, option, region, at, at);
 #ifdef USE_COMBINATION_EXPLOSION_CHECK
   {
-    int offset = at - str;
+    ptrdiff_t offset = at - str;
     STATE_CHECK_BUFF_INIT(msa, end - str, offset, reg->num_comb_exp_check);
   }
 #endif
@@ -3990,7 +3990,7 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
   MATCH_ARG_INIT(msa, option, region, start, global_pos);
 #ifdef USE_COMBINATION_EXPLOSION_CHECK
   {
-    int offset = (MIN(start, range) - str);
+    ptrdiff_t offset = (MIN(start, range) - str);
     STATE_CHECK_BUFF_INIT(msa, end - str, offset, reg->num_comb_exp_check);
   }
 #endif

--- a/regint.h
+++ b/regint.h
@@ -147,7 +147,13 @@
 
 #ifdef RUBY
 
-# define CHECK_INTERRUPT_IN_MATCH_AT rb_thread_check_ints()
+# define CHECK_INTERRUPT_IN_MATCH_AT do { \
+  msa->counter++;                         \
+  if (msa->counter >= 128) {              \
+    msa->counter = 0;                     \
+    rb_thread_check_ints();               \
+  }                                       \
+} while(0)
 # define onig_st_init_table                  st_init_table
 # define onig_st_init_table_with_size        st_init_table_with_size
 # define onig_st_init_numtable               st_init_numtable
@@ -877,6 +883,7 @@ typedef struct {
   void* state_check_buff;
   int   state_check_buff_size;
 #endif
+  int counter;
 } OnigMatchArg;
 
 

--- a/regparse.c
+++ b/regparse.c
@@ -4659,7 +4659,15 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
 	  goto err;
 	}
 
-	len = enclen(env->enc, buf, buf + i);
+	if (env->enc == ONIG_ENCODING_EUC_JP ||
+		env->enc == ONIG_ENCODING_SJIS) {
+	  /* Strict version of enclen does not handle invalid single code
+	   * point for SJIS and EUC-JP...*/
+	  len = enclen_approximate(env->enc, buf, buf + i);
+	}
+	else {
+	  len = enclen(env->enc, buf, buf + i);
+	}
 	if (i < len) {
 	  r = ONIGERR_TOO_SHORT_MULTI_BYTE_STRING;
 	  goto err;


### PR DESCRIPTION
I imported several patches for ruby bundled onigmo.
BTW, the recent ruby bundled onigmo starts to implement matching cache regular expression mechanism that mitigates for ReDOS.
This imported patch set is not included those changes yet.

Related to #5.