### PR TITLE
CMakeLists.txt: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4)
-project(onigmo)
+project(onigmo C)
 
 # Onigmo Version
 set(ONIGMO_VERSION_MAJOR  6)


### PR DESCRIPTION
onigmo is written in c, so only enforce a c compiler

Seen while compiling fluent-bit on buildroot.