### PR TITLE
st: regparse: handle onigmo strict signatures

### DIFF
--- a/st.c
+++ b/st.c
@@ -1600,7 +1600,7 @@ st_update(st_table *tab, st_data_t key,
    different for ST_CHECK and when the current element is removed
    during traversing.  */
 static inline int
-st_general_foreach(st_table *tab, int (*func)(ANYARGS), st_update_callback_func *replace, st_data_t arg,
+st_general_foreach(st_table *tab, st_foreach_callback_func *func, st_update_callback_func *replace, st_data_t arg,
 		   int check_p)
 {
     st_index_t bin;
@@ -1712,14 +1712,14 @@ st_general_foreach(st_table *tab, int (*func)(ANYARGS), st_update_callback_func 
 
 #ifdef RUBY
 int
-st_foreach_with_replace(st_table *tab, int (*func)(ANYARGS), st_update_callback_func *replace, st_data_t arg)
+st_foreach_with_replace(st_table *tab, st_foreach_callback_func *func, st_update_callback_func *replace, st_data_t arg)
 {
     return st_general_foreach(tab, func, replace, arg, TRUE);
 }
 #endif /* RUBY */
 
 int
-st_foreach(st_table *tab, int (*func)(ANYARGS), st_data_t arg)
+st_foreach(st_table *tab, st_foreach_callback_func *func, st_data_t arg)
 {
     return st_general_foreach(tab, func, NULL, arg, FALSE);
 }
@@ -1727,7 +1727,7 @@ st_foreach(st_table *tab, int (*func)(ANYARGS), st_data_t arg)
 #ifdef RUBY
 /* See comments for function st_delete_safe.  */
 int
-st_foreach_check(st_table *tab, int (*func)(ANYARGS), st_data_t arg,
+st_foreach_check(st_table *tab, st_foreach_callback_func *func, st_data_t arg,
                  st_data_t never ATTRIBUTE_UNUSED)
 {
     return st_general_foreach(tab, func, NULL, arg, TRUE);

--- a/st.h
+++ b/st.h
@@ -66,8 +66,8 @@ typedef char st_check_for_sizeof_st_index_t[SIZEOF_VOIDP == (int)sizeof(st_index
 #define SIZEOF_ST_INDEX_T SIZEOF_VOIDP
 
 struct st_hash_type {
-    int (*compare)(ANYARGS /*st_data_t, st_data_t*/); /* st_compare_func* */
-    st_index_t (*hash)(ANYARGS /*st_data_t*/);        /* st_hash_func* */
+    int (*compare)(st_data_t, st_data_t); /* st_compare_func* */
+    st_index_t (*hash)(st_data_t);        /* st_hash_func* */
 };
 
 #define ST_INDEX_BITS (SIZEOF_ST_INDEX_T * CHAR_BIT)
@@ -124,9 +124,10 @@ typedef int st_update_callback_func(st_data_t *key, st_data_t *value, st_data_t 
 /* *key may be altered, but must equal to the old key, i.e., the
  * results of hash() are same and compare() returns 0, otherwise the
  * behavior is undefined */
+typedef int st_foreach_callback_func(st_data_t key, st_data_t value, st_data_t arg, int existing);
 int st_update(st_table *table, st_data_t key, st_update_callback_func *func, st_data_t arg);
-int st_foreach_with_replace(st_table *tab, int (*func)(ANYARGS), st_update_callback_func *replace, st_data_t arg);
-int st_foreach(st_table *, int (*)(ANYARGS), st_data_t);
+int st_foreach_with_replace(st_table *tab, st_foreach_callback_func *func, st_update_callback_func *replace, st_data_t arg);
+int st_foreach(st_table *, st_foreach_callback_func *func, st_data_t);
 int st_foreach_check(st_table *, int (*)(ANYARGS), st_data_t, st_data_t);
 st_index_t st_keys(st_table *table, st_data_t *keys, st_index_t size);
 st_index_t st_keys_check(st_table *table, st_data_t *keys, st_index_t size, st_data_t never);


### PR DESCRIPTION
When using C23 standard, it requests to use concrete function signatures.
Before C23, empty arguments just means skipping validation of function signatures or just indicating 0 arguments implicitly.
After applying C23 standard, it just means 0 arguments in the function signatures.

This issue is described in https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters.