### PR TITLE
fix: add integer overflow check in st.c...

### DIFF
--- a/st.c
+++ b/st.c
@@ -621,8 +621,8 @@ st_init_table_with_size(const struct st_hash_type *type, st_index_t size)
         }
 #endif
     }
-    tab->entries = (st_table_entry *) malloc(get_allocated_entries(tab)
-					     * sizeof(st_table_entry));
+    tab->entries = (st_table_entry *) calloc(get_allocated_entries(tab),
+					     sizeof(st_table_entry));
 #ifndef RUBY
     if (tab->entries == NULL) {
         st_free_table(tab);
@@ -1349,8 +1349,8 @@ st_copy(st_table *old_tab)
         }
 #endif
     }
-    new_tab->entries = (st_table_entry *) malloc(get_allocated_entries(old_tab)
-						 * sizeof(st_table_entry));
+    new_tab->entries = (st_table_entry *) calloc(get_allocated_entries(old_tab),
+						 sizeof(st_table_entry));
 #ifndef RUBY
     if (new_tab->entries == NULL) {
         st_free_table(new_tab);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `st.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.integer-overflow-malloc |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.integer-overflow-malloc` |
| **File** | `st.c:624` |

**Description**: Arithmetic multiplication used to compute allocation size without overflow check. If the multiplication wraps, a too-small buffer is allocated, leading to heap overflow. Check for overflow before allocating.


## Changes
- `st.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
